### PR TITLE
fix: removes forced styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,8 @@ const YourComponent = () => {
       src="your-video.mp4"
       posterImg="your-poster-image.jpg"
       description="This is a description of the video."
-      width={16}
-      height={9}
       prefersReducedMotion={prefersReducedMotion}
+      style={{'--aspect-ratio': 'calc((9 / 16) * 100%)'}}
       renderReducedMotionFallback={() => (
         <img src="your-fallback-image.jpg" alt="Description of the fallback image." />
       )}
@@ -52,13 +51,11 @@ const YourComponent = () => {
 | --------------------------- | -------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | className                   | String   |                     |                                                                                                                                                                                                                                                                                                                                              |
 | description                 | String   | ""                  | A unique description of the video. A unique hash based on this text will be generated and used as the `aria-describedby` ID for a visually-hidden description of the video in the DOM.                                                                                                                                                       |
-| height                      | Number   |                     | Height of the video. Only used for establishing an aspect ratio, so does not need to be pixel accurate. For example, if the ratio of the video is 16:9, and its dimensions were 1000 x 562, you could pass `9` or `562` and it wouldn't matter, as long as the `width` corresponded to the aspect ratio.                                     |
 | lazyLoadRootMargin          | String   | "0px 0px 400px 0px" | Optional. The `rootMargin` string, as expected by the browser's [IntersectionObserver API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API). By default, the component gets a 400-pixel "look-ahead", which means the detection of whether or not the component is in view checks up to 400px below the viewport. |
 | posterImg                   | String   |                     | Optional. The `poster` attribute of the `<video>` element.                                                                                                                                                                                                                                                                                   |
 | prefersReducedMotion        | Boolean  | false               | Whether the user prefers reduced motion. If `true`, the component will check for the `renderReducedMotionFallback` render prop, and use that instead of the default auto-playing video.                                                                                                                                                      |
 | renderReducedMotionFallback | Function |                     | Render prop to provide fallback content when the user has enabled reduced motion. This is most commonly an image, or a paused video with controls.                                                                                                                                                                                           |
 | src                         | String   |                     | The video source file.                                                                                                                                                                                                                                                                                                                       |
-| width                       | Number   |                     | Width of the video. Only used for establishing an aspect ratio, so does not need to be pixel accurate. For example, if the ratio of the video is 16:9, and its dimensions were 1000 x 562, you could pass `16` or `1000` and it wouldn't matter, as long as the `height` corresponded to the aspect ratio.                                   |
 
 ## Styling
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ const YourComponent = () => {
 
 ## Styling
 
-This component uses the [BEM methodology](https://getbem.com/) for CSS classNames — the block here being `.autoplay-video`. While you aren't likely to need too many style overrides, you will want to import the stylesheet into your app, as it helps with responsiveness and maintaining aspect ratio.
+This component uses the [BEM methodology](https://getbem.com/) for CSS `classNames` — the block here being `.autoplay-video`. While you aren't likely to need too many style overrides, you will want to import the stylesheet into your app, as it helps with responsiveness and maintaining aspect ratio. The default aspect-ratio is configured to display a 16:9 video. You can overwrite that by setting the `--aspect-ratio` CSS variable on the component.
 
 ## Accessibility
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wethegit/react-autoplay-video",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wethegit/react-autoplay-video",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@wethegit/react-hooks": "~1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/react-autoplay-video",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Viewport-aware auto-playing video component for use in React projects.",
   "files": [
     "dist"

--- a/src/lib/components/autoplay-video.jsx
+++ b/src/lib/components/autoplay-video.jsx
@@ -15,14 +15,12 @@ const AutoplayVideo = forwardRef(
     {
       className,
       description,
-      height,
       inViewRootMargin,
       paused,
       posterImg,
       prefersReducedMotion,
       renderReducedMotionFallback,
       src,
-      width,
     },
     inputRef
   ) => {
@@ -67,16 +65,7 @@ const AutoplayVideo = forwardRef(
     }, [isInView, srcAdded, paused, prefersReducedMotion])
 
     return (
-      <div
-        ref={setInViewRef}
-        className={classnames(["autoplay-video", className])}
-        {...(width &&
-          height && {
-            style: {
-              "--aspect-ratio": `${parseFloat((height / width).toFixed(4)) * 100}%`,
-            },
-          })}
-      >
+      <div ref={setInViewRef} className={classnames(["autoplay-video", className])}>
         {prefersReducedMotion && renderReducedMotionFallback ? (
           <div className="autoplay-video__media">{renderReducedMotionFallback()}</div>
         ) : (
@@ -114,14 +103,12 @@ AutoplayVideo.defaultProps = {
 AutoplayVideo.propTypes = {
   className: PropTypes.string,
   description: PropTypes.string,
-  height: PropTypes.number.isRequired,
   inViewRootMargin: PropTypes.string.isRequired,
   paused: PropTypes.bool,
   posterImg: PropTypes.string,
   prefersReducedMotion: PropTypes.bool.isRequired,
   renderReducedMotionFallback: PropTypes.func,
   src: PropTypes.string,
-  width: PropTypes.number.isRequired,
 }
 
 AutoplayVideo.displayName = "AutoplayVideo"


### PR DESCRIPTION
# Goal

This PR removes the inline styles for the aspect ratio. Makes it harder to style the component and we also already have a fallback inside the css declaration.  
The width and height weren't being used anywhere else either.  