### PR TITLE
fix: classname mismatch for video description

### DIFF
--- a/src/lib/components/autoplay-video.module.css
+++ b/src/lib/components/autoplay-video.module.css
@@ -1,4 +1,4 @@
-.autoplay-video-util-visually-hidden {
+.visually-hidden {
   border: 0;
   clip: rect(0 0 0 0);
   height: 1px;


### PR DESCRIPTION
## Description
This fixes the incorrect classname used for video description. 
`autoplay-video-util-visually-hidden` vs `visually-hidden` 

We are updating to use `visually-hidden`.