### PR TITLE
fix: disable tabbing focus in Firefox

### DIFF
--- a/src/lib/components/autoplay-video.tsx
+++ b/src/lib/components/autoplay-video.tsx
@@ -105,6 +105,7 @@ export function AutoplayVideo({
             </p>
           )}
           <video
+            tabIndex={-1}
             aria-describedby={descriptionID}
             autoPlay
             className={styles["autoplay-video__media"]}


### PR DESCRIPTION
## Description

Firefox focuses `<video>` element even if there are no controls. When used in gallery/carousel, users can tab through gallery items which conflicts with Gallery's tab navigation setup. 

We are explicitly adding `tabindex="-1"`.  