### PR TITLE
[Release] - Video description and video focus patch

### DIFF
--- a/.changeset/good-owls-wait.md
+++ b/.changeset/good-owls-wait.md
@@ -1,0 +1,5 @@
+---
+"@wethegit/react-autoplay-video": patch
+---
+
+Fix video description classname and make the autoplaying video element not focusable explicitly

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/react-autoplay-video",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Viewport-aware auto-playing video component for use in React projects.",
   "files": [
     "dist"

--- a/src/lib/components/autoplay-video.module.css
+++ b/src/lib/components/autoplay-video.module.css
@@ -1,4 +1,4 @@
-.autoplay-video-util-visually-hidden {
+.visually-hidden {
   border: 0;
   clip: rect(0 0 0 0);
   height: 1px;

--- a/src/lib/components/autoplay-video.tsx
+++ b/src/lib/components/autoplay-video.tsx
@@ -105,6 +105,7 @@ export function AutoplayVideo({
             </p>
           )}
           <video
+            tabIndex={-1}
             aria-describedby={descriptionID}
             autoPlay
             className={styles["autoplay-video__media"]}


### PR DESCRIPTION
This PR fixes: 
- Incorrect class name used on video description
- Remove tab focus from autoplaying video, which is default behaviour in Firefox.

This PR merges #114  & #115